### PR TITLE
Fix existing package file

### DIFF
--- a/lib/pkgbuild.coffee
+++ b/lib/pkgbuild.coffee
@@ -11,7 +11,7 @@ module.exports =
     makepkg: ()->
         if activeEditor
             if /PKGBUILD$/.test filePath
-                exec "cd #{fileDirectory} && makepkg", (err, stdout, stderr)->
+                exec "cd #{fileDirectory} && makepkg -f", (err, stdout, stderr)->
                     notifications.addError stderr + "filePath is #{filePath}; fileDirectory is #{fileDirectory}", dismissable: true if err
                     notifications.addSuccess "Package built!" unless err
 


### PR DESCRIPTION
Fixes this issue when using `makepkg` and the file already exists

```
==> ERROR: A package has already been built. (use -f to overwrite) 
filePath is /home/bilal/Dropbox/Projets/AUR\ Packages/gnome-twofactorauth/PKGBUILD; 
fileDirectory is /home/bilal/Dropbox/Projets/AUR\ Packages/gnome-twofactorauth
```
