### PR TITLE
better fix for #2

### DIFF
--- a/lib/pkgbuild.coffee
+++ b/lib/pkgbuild.coffee
@@ -5,34 +5,31 @@ notifications = atom.notifications
 if activeEditor
     filePath = activeEditor.getPath().split(" ").join("\\ ")
     fileDirectory = String(filePath).split('/')
+    fileName = fileDirectory[fileDirectory.length - 1]
     fileDirectory.pop()
     fileDirectory = fileDirectory.join("/")
 
 module.exports =
     makepkg: ()->
-        if activeEditor
-            if /PKGBUILD$/.test filePath
-                exec "cd #{fileDirectory} && makepkg -f", (err, stdout, stderr)->
-                    notifications.addError stderr + "filePath is #{filePath}; fileDirectory is #{fileDirectory}", dismissable: true if err
-                    notifications.addSuccess "Package built!" unless err
+        if activeEditor && /PKGBUILD$/.test filePath
+            exec "cd #{fileDirectory} && makepkg -f", (err, stdout, stderr)->
+                notifications.addError stderr + "filePath is #{filePath}; fileDirectory is #{fileDirectory}", dismissable: true if err
+                notifications.addSuccess "Package built!" unless err
 
     mksrcinfo: ()->
-        if activeEditor
-            if /PKGBUILD$/.test filePath
-                exec "cd #{fileDirectory} && mksrcinfo", (err, stdout, stderr)->
-                    notifications.addError stderr + "cd #{fileDirectory} && mksrcinfo", dismissable: true if err
-                    notifications.addSuccess ".SRCINFO updated" unless err
+        if activeEditor /PKGBUILD$/.test filePath
+            exec "cd #{fileDirectory} && mksrcinfo", (err, stdout, stderr)->
+                notifications.addError stderr + "cd #{fileDirectory} && mksrcinfo", dismissable: true if err
+                notifications.addSuccess ".SRCINFO updated" unless err
 
     namcap: ()->
-        if activeEditor
-            if /PKGBUILD$/.test filePath
-                exec "namcap #{filePath}", (err, stdout, stderr)->
-                    notifications.addError stderr + "command is: namcap #{filePath}", dismissable: true if err
-                    notifications.addSuccess "Your PKGBUILD seems fine.\nBuild a package from it and run namcap \non said package to perform further checks." unless err
+        if activeEditor && /PKGBUILD$/.test filePath
+            exec "cd #{fileDirectory} && namcap #{fileName}", (err, stdout, stderr)->
+                notifications.addError stderr + "command is: namcap #{filePath}", dismissable: true if err
+                notifications.addSuccess "Your PKGBUILD seems fine.\nBuild a package from it and run namcap \non said package to perform further checks." unless err
 
     updpkgsums: ()->
-        if activeEditor
-            if /PKGBUILD$/.test filePath
-                exec "updpkgsums #{filePath}", (err, stdout, stderr)->
-                    notifications.addError stderr + "command is: updpkgsums #{filePath}", dismissable: true if err
-                    notifications.addSuccess "PKGBUILD checksums updated" unless err
+        if activeEditor && /PKGBUILD$/.test filePath
+            exec "updpkgsums #{filePath}", (err, stdout, stderr)->
+                notifications.addError stderr + "command is: updpkgsums #{filePath}", dismissable: true if err
+                notifications.addSuccess "PKGBUILD checksums updated" unless err


### PR DESCRIPTION
The namcap does detect the `\` correctly. Fixed that by getting the filename, using cd to go to the directory and using `namcap filename` (which must be PKGBUILD)
