### PR TITLE
fix a typo

### DIFF
--- a/lib/pkgbuild.coffee
+++ b/lib/pkgbuild.coffee
@@ -17,7 +17,7 @@ module.exports =
                 notifications.addSuccess "Package built!" unless err
 
     mksrcinfo: ()->
-        if activeEditor /PKGBUILD$/.test filePath
+        if activeEditor && /PKGBUILD$/.test filePath
             exec "cd #{fileDirectory} && mksrcinfo", (err, stdout, stderr)->
                 notifications.addError stderr + "cd #{fileDirectory} && mksrcinfo", dismissable: true if err
                 notifications.addSuccess ".SRCINFO updated" unless err


### PR DESCRIPTION
forgot a "&&"
I think that the package is quite stable now :+1: 
